### PR TITLE
populationsim dev version install from git

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ Latest ABM development tools with ActivitySim, PopulationSim, and SciPy tools.
 mamba remove -y --name abm_dev --all
 mamba env create -n abm_dev -f abm_dev.yml
 mamba activate abm_dev
+# # install development version of activitysim (optional)
+# pip uninstall activitysim
+# pip install git+https://github.com/TransLinkForecasting/activitysim@main --upgrade
+# install development version of populationsim (required as of Sep 22, 2023)
+pip uninstall populationsim
+pip install git+https://github.com/TransLinkForecasting/populationsim@master --upgrade
 # install geopandas and its dependencies
 setx GDAL_VERSION "3.3.3"
 pip install source/gpd/GDAL-3.3.3-cp39-cp39-win_amd64.whl --upgrade

--- a/abm_dev.sh
+++ b/abm_dev.sh
@@ -10,9 +10,10 @@ mamba activate abm_dev
 pip install "activitysim==1.2.1" --upgrade
 # # optionally, override old versions of activitysim with development version
 # pip install source/activitysim/activitysim-1.2.1.dev8+gd876d08c-py3-none-any.whl --upgrade
-# populationsim latest, dependencies: https://github.com/ActivitySim/populationsim/blob/master/setup.py
+# # install populationsim latest, dependencies: https://github.com/ActivitySim/populationsim/blob/master/setup.py
 # pip install source/popsim/populationsim-0.5.1.zip --upgrade
-pip install "populationsim==0.5.1" --upgrade
+# or install development version of populationsim
+pip install git+https://github.com/TransLinkForecasting/populationsim@master --upgrade
 # additional mamba packages, note:
 # - mord and pylogit - are for modeling
 # - contextily folium branca cycler kiwisolver - are for GIS


### PR DESCRIPTION
we found deprecation bugs related to numpy and pandas in populationsim, so we need to install a development version from our fork of populationsim from here https://github.com/TransLinkForecasting/populationsim